### PR TITLE
Increasing default memory size to 128, and increasing max entry size fro...

### DIFF
--- a/templates/memcached.conf.j2
+++ b/templates/memcached.conf.j2
@@ -20,7 +20,7 @@ logfile /var/log/memcached.log
 # Start with a cap of 64 megs of memory. It's reasonable, and the daemon default
 # Note that the daemon will grow to this size, but does not start out holding this much
 # memory
--m {{ memcached_memory|default('64') }}
+-m {{ memcached_memory|default('128') }}
 
 # Default connection port is 11211
 -p {{ memcached_port|default('11211') }}
@@ -45,3 +45,7 @@ logfile /var/log/memcached.log
 
 # Maximize core file limit
 # -r
+
+# Increase max entry size (default 1M)
+# TES Drupal isn't handling field cache very well.
+-I 5M


### PR DESCRIPTION
...m 1M to 5M (this is to fix an issue on TES where the field list cache was too big for memcache, which broke the courses page)
